### PR TITLE
Store Clear

### DIFF
--- a/src/app/components/user/list/user-list.component.html
+++ b/src/app/components/user/list/user-list.component.html
@@ -10,7 +10,7 @@
       <app-user-card
         *ngFor="let user of userList$ | async"
         [user]="user"
-        (selected)="setSelectedUser($event)"
+        (selected)="handleUserSelection($event)"
       ></app-user-card>
     </div>
   </ng-template>

--- a/src/app/components/user/list/user-list.component.spec.ts
+++ b/src/app/components/user/list/user-list.component.spec.ts
@@ -5,12 +5,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { mockUserList } from '@app/mocks';
 import {
   AppState,
-  SetSelectedUserID,
-  USER_STATE_KEY,
-  POST_STATE_KEY,
-  initialPostState,
   COMMENT_STATE_KEY,
   initialCommentState,
+  initialPostState,
+  initialUserState,
+  POST_STATE_KEY,
+  SetSelectedUserID,
+  USER_STATE_KEY,
 } from '@app/store';
 import { spinnerSelector, UiModule } from '@app/ui';
 import { Store } from '@ngrx/store';
@@ -25,7 +26,6 @@ describe('UserListComponent', () => {
   let fixture: ComponentFixture<UserListComponent>;
   let store: MockStore<AppState>;
   const storeStates = {
-    empty: { loading: false, users: [], error: false, selectedUserID: null },
     loading: { loading: true, users: [], error: false, selectedUserID: null },
     error: { loading: false, users: [], error: true, selectedUserID: null },
     usersLoaded: {
@@ -38,6 +38,11 @@ describe('UserListComponent', () => {
   const userStateKey = USER_STATE_KEY;
   const postStateKey = POST_STATE_KEY;
   const commentStateKey = COMMENT_STATE_KEY;
+  const initialState: AppState = {
+    [userStateKey]: initialUserState,
+    [postStateKey]: initialPostState,
+    [commentStateKey]: initialCommentState,
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -45,10 +50,7 @@ describe('UserListComponent', () => {
       declarations: [UserListComponent, UserCardComponent],
       providers: [
         provideMockStore({
-          initialState: {
-            [userStateKey]: {},
-            [postStateKey]: initialPostState,
-          },
+          initialState,
         }),
       ],
     }).compileComponents();
@@ -58,20 +60,13 @@ describe('UserListComponent', () => {
   });
 
   it('should create', () => {
-    store.setState({
-      [userStateKey]: { ...storeStates.empty },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
-    });
-    fixture.detectChanges();
     expect(component).toBeTruthy();
   });
 
   it(`should display the spinner while the user list is loading`, () => {
     store.setState({
+      ...initialState,
       [userStateKey]: { ...storeStates.loading },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
     });
     fixture.detectChanges();
     const spinner = fixture.debugElement
@@ -82,9 +77,8 @@ describe('UserListComponent', () => {
 
   it('should display one card for each user', () => {
     store.setState({
+      ...initialState,
       [userStateKey]: { ...storeStates.usersLoaded },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
     });
     fixture.detectChanges();
     const cards = fixture.debugElement.queryAll(By.css(userCardSelector));
@@ -93,9 +87,8 @@ describe('UserListComponent', () => {
 
   it('should display the error message if users fail to load', () => {
     store.setState({
+      ...initialState,
       [userStateKey]: { ...storeStates.error },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
     });
     fixture.detectChanges();
     const error = fixture.debugElement.query(By.css('.error')).nativeElement;
@@ -105,9 +98,8 @@ describe('UserListComponent', () => {
   it('should dispatch action to set selected user id after clicking on a card', () => {
     spyOn(store, 'dispatch');
     store.setState({
+      ...initialState,
       [userStateKey]: { ...storeStates.usersLoaded },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
     });
     fixture.detectChanges();
     fixture.debugElement
@@ -123,9 +115,8 @@ describe('UserListComponent', () => {
     const route: ActivatedRoute = TestBed.inject(ActivatedRoute);
     spyOn(router, 'navigate');
     store.setState({
+      ...initialState,
       [userStateKey]: { ...storeStates.usersLoaded },
-      [postStateKey]: initialPostState,
-      [commentStateKey]: initialCommentState,
     });
     fixture.detectChanges();
     fixture.debugElement

--- a/src/app/components/user/list/user-list.component.ts
+++ b/src/app/components/user/list/user-list.component.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
   AppState,
+  ClearPosts,
+  ClearSelectedUserID,
   LoadUsers,
   SetSelectedUserID,
   SimpleUser,
@@ -33,17 +35,14 @@ export class UserListComponent implements OnDestroy {
     private router: Router,
     private route: ActivatedRoute
   ) {
+    this.clearPreviousUserData();
     this.listenUserStoreData();
     this.loadUserList();
   }
 
-  private loadUserList() {
-    this.userList$.pipe(take(1)).subscribe((users) => {
-      // Dispatch action to load users if user list is empty.
-      if (!users || !users.length) {
-        this.store.dispatch(new LoadUsers());
-      }
-    });
+  private clearPreviousUserData() {
+    this.store.dispatch(new ClearSelectedUserID());
+    this.store.dispatch(new ClearPosts());
   }
 
   private listenUserStoreData() {
@@ -61,10 +60,24 @@ export class UserListComponent implements OnDestroy {
     );
   }
 
-  public setSelectedUser(id: number) {
-    // Dispatch action to set selected user id in Store.
+  private loadUserList() {
+    this.userList$.pipe(take(1)).subscribe((users) => {
+      if (!users || !users.length) {
+        this.store.dispatch(new LoadUsers());
+      }
+    });
+  }
+
+  public handleUserSelection(id: number) {
+    this.setSelectedUser(id);
+    this.navigateToUserProfile();
+  }
+
+  private setSelectedUser(id: number) {
     this.store.dispatch(new SetSelectedUserID(id));
-    // Navigate to selected user's profile.
+  }
+
+  private navigateToUserProfile() {
     this.router.navigate([USER_PROFILE_PATH], {
       relativeTo: this.route.parent,
     });

--- a/src/app/components/user/profile/user-profile.component.html
+++ b/src/app/components/user/profile/user-profile.component.html
@@ -29,7 +29,7 @@
   <span
     class="post"
     *ngFor="let post of posts$ | async"
-    (click)="openPost(post.id)"
+    (click)="handlePostSelection(post.id)"
   >
     <b>#{{ post.id }}:</b> {{ post.title }}
   </span>

--- a/src/app/components/user/profile/user-profile.component.ts
+++ b/src/app/components/user/profile/user-profile.component.ts
@@ -35,18 +35,15 @@ export class UserProfileComponent implements OnDestroy {
     private router: Router,
     private route: ActivatedRoute
   ) {
+    this.listenProfileData();
+  }
+
+  private listenProfileData() {
     // Get selected user from store
     this.user$ = this.store.pipe(
       select(userQuery.getSelectedUser),
       filter((user) => !!user),
-      // Dispatch action to load user posts
-      tap((user) => {
-        if (this.currentUserID === user.id) {
-          return;
-        }
-        this.currentUserID = user.id;
-        this.store.dispatch(new LoadPosts(user.id));
-      }),
+      tap((user) => this.loadPosts(user.id)),
       untilDestroyed(this)
     );
     this.posts$ = this.store.pipe(
@@ -55,10 +52,24 @@ export class UserProfileComponent implements OnDestroy {
     );
   }
 
-  public openPost(id: number) {
-    // Set selected post ID
+  private loadPosts(id: number) {
+    if (this.currentUserID === id) {
+      return;
+    }
+    this.currentUserID = id;
+    this.store.dispatch(new LoadPosts(id));
+  }
+
+  public handlePostSelection(id: number) {
+    this.setSelectedPostID(id);
+    this.navigateToPost();
+  }
+
+  private setSelectedPostID(id: number) {
     this.store.dispatch(new SetSelectedPostID(id));
-    // Navigate to Post Component
+  }
+
+  private navigateToPost() {
     this.router.navigate([USER_POST_PATH], {
       relativeTo: this.route.parent,
     });

--- a/src/app/store/comment/comment.actions.ts
+++ b/src/app/store/comment/comment.actions.ts
@@ -6,6 +6,7 @@ export enum CommentActionTypes {
   LoadComments = '[Comment] Load Comments',
   LoadCommentsSuccess = '[Comment] Load Comments Success',
   LoadCommentsError = '[Comment] Load Comments Error',
+  ClearComments = '[Comment] Clear Comments',
 }
 
 export class LoadComments implements Action {
@@ -24,7 +25,12 @@ export class LoadCommentsError implements Action {
   public readonly type = CommentActionTypes.LoadCommentsError;
 }
 
+export class ClearComments implements Action {
+  public readonly type = CommentActionTypes.ClearComments;
+}
+
 export type CommentAction =
   | LoadComments
   | LoadCommentsSuccess
-  | LoadCommentsError;
+  | LoadCommentsError
+  | ClearComments;

--- a/src/app/store/comment/comment.reducer.spec.ts
+++ b/src/app/store/comment/comment.reducer.spec.ts
@@ -4,6 +4,7 @@ import {
   LoadComments,
   LoadCommentsError,
   LoadCommentsSuccess,
+  ClearComments,
 } from './comment.actions';
 import { commentReducer } from './comment.reducer';
 import { initialCommentState } from './comment.state';
@@ -46,6 +47,16 @@ describe('commentReducer', () => {
         loading: false,
         error: true,
       });
+    });
+  });
+
+  describe('ClearComments', () => {
+    it('should set comments to an empty array', () => {
+      const newState = commentReducer(
+        { ...initialCommentState, comments: mockCommentList },
+        new ClearComments()
+      );
+      expect(newState).toEqual({ ...initialCommentState });
     });
   });
 

--- a/src/app/store/comment/comment.reducer.ts
+++ b/src/app/store/comment/comment.reducer.ts
@@ -25,6 +25,11 @@ export const commentReducer = (
         loading: false,
         error: true,
       };
+    case CommentActionTypes.ClearComments:
+      return {
+        ...state,
+        comments: [],
+      };
     default:
       return state;
   }

--- a/src/app/store/post/post.actions.ts
+++ b/src/app/store/post/post.actions.ts
@@ -6,6 +6,7 @@ export enum PostActionTypes {
   LoadPostsSuccess = '[Post] Load Posts Success',
   LoadPostsError = '[Post] Load Posts Error',
   SetSelectedPostID = '[Post] Set Selected Post ID',
+  ClearPosts = '[Post] Clear Posts',
 }
 
 export class LoadPosts implements Action {
@@ -30,8 +31,13 @@ export class SetSelectedPostID implements Action {
   public constructor(public id: number) {}
 }
 
+export class ClearPosts implements Action {
+  public readonly type = PostActionTypes.ClearPosts;
+}
+
 export type PostAction =
   | LoadPosts
   | LoadPostsSuccess
   | LoadPostsError
-  | SetSelectedPostID;
+  | SetSelectedPostID
+  | ClearPosts;

--- a/src/app/store/post/post.actions.ts
+++ b/src/app/store/post/post.actions.ts
@@ -1,4 +1,5 @@
 import { Action } from '@ngrx/store';
+
 import { Post } from './post.model';
 
 export enum PostActionTypes {
@@ -6,6 +7,7 @@ export enum PostActionTypes {
   LoadPostsSuccess = '[Post] Load Posts Success',
   LoadPostsError = '[Post] Load Posts Error',
   SetSelectedPostID = '[Post] Set Selected Post ID',
+  ClearSelectedPostID = '[Post] Clear Selected Post ID',
   ClearPosts = '[Post] Clear Posts',
 }
 
@@ -31,6 +33,10 @@ export class SetSelectedPostID implements Action {
   public constructor(public id: number) {}
 }
 
+export class ClearSelectedPostID implements Action {
+  public readonly type = PostActionTypes.ClearSelectedPostID;
+}
+
 export class ClearPosts implements Action {
   public readonly type = PostActionTypes.ClearPosts;
 }
@@ -40,4 +46,5 @@ export type PostAction =
   | LoadPostsSuccess
   | LoadPostsError
   | SetSelectedPostID
-  | ClearPosts;
+  | ClearPosts
+  | ClearSelectedPostID;

--- a/src/app/store/post/post.reducer.spec.ts
+++ b/src/app/store/post/post.reducer.spec.ts
@@ -2,6 +2,7 @@ import { mockPostList } from '@app/mocks';
 
 import {
   ClearPosts,
+  ClearSelectedPostID,
   LoadPosts,
   LoadPostsError,
   LoadPostsSuccess,
@@ -68,6 +69,14 @@ describe('postReducer', () => {
         ...initialPostState,
       });
     });
+  });
+
+  describe('ClearSelectedPostID', () => {
+    const newState = postReducer(
+      { ...initialPostState, selectedPostID: 5 },
+      new ClearSelectedPostID()
+    );
+    expect(newState).toEqual(initialPostState);
   });
 
   describe('Unknown action', () => {

--- a/src/app/store/post/post.reducer.spec.ts
+++ b/src/app/store/post/post.reducer.spec.ts
@@ -1,6 +1,7 @@
 import { mockPostList } from '@app/mocks';
 
 import {
+  ClearPosts,
   LoadPosts,
   LoadPostsError,
   LoadPostsSuccess,
@@ -53,6 +54,18 @@ describe('postReducer', () => {
       expect(newState).toEqual({
         ...initialPostState,
         selectedPostID: 5,
+      });
+    });
+  });
+
+  describe('ClearPosts', () => {
+    it('should set posts to an empty array', () => {
+      const newState = postReducer(
+        { ...initialPostState, posts: mockPostList },
+        new ClearPosts()
+      );
+      expect(newState).toEqual({
+        ...initialPostState,
       });
     });
   });

--- a/src/app/store/post/post.reducer.ts
+++ b/src/app/store/post/post.reducer.ts
@@ -35,6 +35,11 @@ export const postReducer = (
         ...state,
         posts: [],
       };
+    case PostActionTypes.ClearSelectedPostID:
+      return {
+        ...state,
+        selectedPostID: null,
+      };
     default:
       return state;
   }

--- a/src/app/store/post/post.reducer.ts
+++ b/src/app/store/post/post.reducer.ts
@@ -30,6 +30,11 @@ export const postReducer = (
         ...state,
         selectedPostID: action.id,
       };
+    case PostActionTypes.ClearPosts:
+      return {
+        ...state,
+        posts: [],
+      };
     default:
       return state;
   }

--- a/src/app/store/user/user.actions.ts
+++ b/src/app/store/user/user.actions.ts
@@ -7,6 +7,7 @@ export enum UserActionTypes {
   LoadUsersSuccess = '[User] Load Users Success',
   LoadUsersError = '[User] Load Users Error',
   SetSelectedUserID = '[User] Set Selected User ID',
+  ClearSelectedUserID = '[User] Clear Selected User ID',
 }
 
 export class LoadUsers implements Action {
@@ -29,8 +30,13 @@ export class SetSelectedUserID implements Action {
   public constructor(public id: number) {}
 }
 
+export class ClearSelectedUserID implements Action {
+  public readonly type = UserActionTypes.ClearSelectedUserID;
+}
+
 export type UserAction =
   | LoadUsers
   | LoadUsersSuccess
   | LoadUsersError
-  | SetSelectedUserID;
+  | SetSelectedUserID
+  | ClearSelectedUserID;

--- a/src/app/store/user/user.reducer.spec.ts
+++ b/src/app/store/user/user.reducer.spec.ts
@@ -5,6 +5,7 @@ import {
   LoadUsersError,
   LoadUsersSuccess,
   SetSelectedUserID,
+  ClearSelectedUserID,
 } from './user.actions';
 import { userReducer } from './user.reducer';
 import { initialUserState } from './user.state';
@@ -54,6 +55,16 @@ describe('UserReducer', () => {
         ...initialUserState,
         selectedUserID: 5,
       });
+    });
+  });
+
+  describe('ClearSelectedUserID', () => {
+    it('should clear the selected user ID', () => {
+      const newState = userReducer(
+        { ...initialUserState, selectedUserID: 5 },
+        new ClearSelectedUserID()
+      );
+      expect(newState).toEqual({ ...initialUserState });
     });
   });
 

--- a/src/app/store/user/user.reducer.ts
+++ b/src/app/store/user/user.reducer.ts
@@ -30,6 +30,11 @@ export const userReducer = (
         ...state,
         selectedUserID: action.id,
       };
+    case UserActionTypes.ClearSelectedUserID:
+      return {
+        ...state,
+        selectedUserID: null,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
This PR implements Actions that clear data from Store that is no longer needed. This fixes a bug where data from a previously selected user/post appears for a brief moment in user-profile and user-post until the data for the current user/post is loaded.