### PR TITLE
App: scroll to top after navigating between pages

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -83,6 +83,14 @@ describe('AppComponent', () => {
     });
   });
 
+  it('should scroll to top when NavigationEnd events occur', () => {
+    router = TestBed.inject(Router);
+    const route = TestBed.inject(ActivatedRoute);
+    spyOn(window, 'scrollTo');
+    getElementBySelector(fixture, 'button').click();
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
   it('should initially display the user list component', () => {
     const userList = getElementBySelector(fixture, userListSelector);
     expect(userList).toBeTruthy();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,8 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { USER_LIST_PATH } from '@app/user';
+import { untilDestroyed } from 'ngx-take-until-destroy';
+import { filter } from 'rxjs/operators';
 
 import { APP_CONSTANTS } from './app.constants';
 
@@ -9,15 +11,30 @@ import { APP_CONSTANTS } from './app.constants';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   public title = APP_CONSTANTS.AppTitle;
   public buttonText = 'User List';
 
-  public constructor(private router: Router, private route: ActivatedRoute) {}
+  public constructor(private router: Router, private route: ActivatedRoute) {
+    this.setupScrollToTopOnNavigation();
+  }
+
+  private setupScrollToTopOnNavigation() {
+    this.router.events
+      .pipe(
+        untilDestroyed(this),
+        filter((event) => event instanceof NavigationEnd)
+      )
+      .subscribe((event) => {
+        window.scrollTo(0, 0);
+      });
+  }
 
   public navigateToUserList() {
     this.router.navigate([USER_LIST_PATH], {
       relativeTo: this.route.parent,
     });
   }
+
+  public ngOnDestroy() {}
 }


### PR DESCRIPTION
When selecting a user which is not at the top of the list, the user profile was not loaded at the top position. This PR corrects this behavior.